### PR TITLE
V 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,46 @@
-# Lamah
-This Repository fork from DroidsOnRoids
+# Lamah GraphHopper Navigation Android
+
+This repository is forked from DroidsOnRoids and updated for Android 16KB page size compatibility.
+
+**Current Version:** `0.4.0`
+
+## Version 0.4.0 Updates
+- ✅ Android 16KB page size compatible (Google Play requirement)
+- ✅ Updated to SDK 34 (Android 14)
+- ✅ Upgraded Mapbox SDK to 11.7.1
+- ✅ Java 17 support
+- ✅ Modern Gradle 8.4 & AGP 8.1.4
 
 ## To use or update this package
-- add github.properties file in root folder.
-- add username & token in file.
+- Add `github.properties` file in root folder
+- Add username & token:
+  ```
   username=lamah
-  token=[generate_access_token](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+  token=[your_github_token]
+  ```
+  [Generate token here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
-## build new version from package
-in root project folder:
-- update version variable in build.gradle under publications.
-- run.
-    ```
-    ./gradlew publish
-    ```
-some times you face error with
+## Build and Test
+```bash
+# Clean build
+./gradlew clean
+
+# Run tests
+./gradlew :navigation-android:test
+
+# Build release AAR
+./gradlew :navigation-android:assembleRelease
+
+# Output location:
+# navigation-android/build/outputs/aar/navigation-android-release.aar
 ```
-Invalid publication 'gpr': artifact file does not exist : build/libs/navigation-android.jar'
-```
-you can fix it rename the navigation-android$version.jar to navigation-android.jar
+
+## Publish new version
+1. Update version in `build.gradle` under publications (line 81)
+2. Build and test (see commands above)
+3. Publish: `./gradlew publish`
+
+**Troubleshooting:** If you get `artifact file does not exist` error, rename `navigation-android$version.jar` to `navigation-android.jar`
 
 
 # Navigation SDK
@@ -41,8 +63,49 @@ It is 100% open source and was forked 2018 from Mapbox due to [licensing issues]
 If you are looking to include this inside your project, please also have a look into the
 [Android example](https://github.com/graphhopper/graphhopper-navigation-example).
 
-Add this snippet to your `build.gradle` file to use this SDK (`libandroid-navigation`):
+Add this snippet to your `build.gradle` file to use this SDK:
 
+```gradle
+implementation 'com.lamah.graphhopper:navigation-android:0.4.0'
 ```
-implementation 'com.graphhopper.navigation:navigation-android:0.1.0'
+
+**Requirements:**
+- minSdkVersion: 21+
+- compileSdkVersion: 34+
+- Java 17+
+
+## 16KB Page Size Compatibility
+
+This library is **16KB compatible** (no native libraries).
+
+### Verify the Library
+```bash
+# 1. Build the library
+./gradlew :navigation-android:assembleRelease
+
+# 2. Check the AAR for native libraries (.so files)
+# Run this from project root:
+unzip -l ./navigation-android/build/outputs/aar/navigation-android-release.aar | grep "jni/"
+
+# Empty result = No native libraries = 16KB compatible ✅
 ```
+
+**What is AAR?** Android Archive file - like a ZIP containing compiled code, resources, and native libraries (if any).
+
+### Verify in Your App
+**Easiest Method (Recommended):**
+1. Integrate this library in your app
+2. Build your app: `./gradlew assembleRelease` or `./gradlew bundleRelease`
+3. Upload APK/AAB to Play Console Internal Testing track
+4. Google automatically validates 16KB compatibility ✅
+
+**Manual Check:**
+```bash
+# In your app project
+./gradlew assembleRelease
+
+# Check all native libraries in your APK
+unzip -l app/build/outputs/apk/release/app-release.apk | grep "\.so$"
+```
+
+All native libraries from dependencies must be 16KB aligned. This library has none, so it's compliant.

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,14 @@
-apply plugin: 'com.github.kt3k.coveralls'
-
 buildscript {
     apply from: "${rootDir}/gradle/dependencies.gradle"
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://plugins.gradle.org/m2' }
+        gradlePluginPortal()
     }
     dependencies {
         classpath pluginDependencies.gradle
-        classpath pluginDependencies.coveralls
         classpath pluginDependencies.errorprone
         classpath pluginDependencies.dependencyUpdates
     }
@@ -24,8 +22,9 @@ task testReport(type: TestReport, group: 'Build') {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://plugins.gradle.org/m2' }
+        gradlePluginPortal()
     }
 
     group = GROUP
@@ -44,10 +43,10 @@ subprojects {
     afterEvaluate { project ->
         task sourcesJar(type: Jar) {
             if (pluginManager.hasPlugin('com.android.library')) {
-                classifier 'sources'
+                archiveClassifier = 'sources'
                 from android.sourceSets.main.java.srcDirs
             } else {
-                classifier 'sources'
+                archiveClassifier = 'sources'
                 from sourceSets.main.allSource
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ subprojects {
 
                     groupId project.group
                     artifactId project.name
-                    version '0.4.1'
+                    version '0.4.2'
                     artifact getArtifactPath()
 
                     pom {

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ subprojects {
 
                     groupId project.group
                     artifactId project.name
-                    version '0.3.2'
+                    version '0.4.0'
                     artifact getArtifactPath()
 
                     pom {

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ subprojects {
 
                     groupId project.group
                     artifactId project.name
-                    version '0.4.0'
+                    version '0.4.1'
                     artifact getArtifactPath()
 
                     pom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,10 +22,18 @@ POM_DEVELOPER_NAME=lamah-co
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048M
+org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.caching=true
+
 android.useAndroidX=true
+android.enableJetifier=true
+
+# Enable non-transitive R classes for faster builds
+android.nonTransitiveRClass=true
+android.nonFinalResIds=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,8 +8,7 @@ ext {
 
   version = [
           mapboxMapSdk       : '11.7.1',
-          mapboxSdkServices  : '5.8.0',
-          mapboxCore         : '4.0.0',
+          mapboxCommon       : '24.7.1',
           autoValue          : '1.10.4',
           junit              : '4.13.2',
           mockito            : '5.6.0',
@@ -30,9 +29,7 @@ ext {
   dependenciesList = [
           // mapbox - Using Maps SDK v11
           mapboxMapSdk           : "com.mapbox.maps:android:${version.mapboxMapSdk}",
-          mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
-          mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
-          mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
+          mapboxCommon           : "com.mapbox.common:common:${version.mapboxCommon}",
 
           // AutoValue
           autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,66 +1,64 @@
 ext {
 
   androidVersions = [
-      minSdkVersion    : 21,
-      targetSdkVersion : 29,
-      compileSdkVersion: 29,
+          minSdkVersion    : 21,
+          targetSdkVersion : 34,
+          compileSdkVersion: 34,
   ]
 
   version = [
-      mapboxMapSdk       : '9.2.1',
-      mapboxSdkServices  : '5.8.0',
-      mapboxCore         : '3.2.0',
-      autoValue          : '1.7.4',
-      junit              : '4.13.2',
-      mockito            : '3.8.0',
-      hamcrest           : '2.0.0.0',
-      errorprone         : '2.5.1',
-      timber             : '4.7.1',
-      commonsIO          : '2.8.0',
-      robolectric        : '4.5.1',
+          mapboxMapSdk       : '11.7.1',
+          mapboxSdkServices  : '5.8.0',
+          mapboxCore         : '3.1.0',
+          autoValue          : '1.10.4',
+          junit              : '4.13.2',
+          mockito            : '5.6.0',
+          hamcrest           : '2.2',
+          errorprone         : '2.23.0',
+          timber             : '5.0.1',
+          commonsIO          : '2.15.0',
+          robolectric        : '4.11.1',
   ]
 
   pluginVersion = [
-      checkstyle       : '8.2',
-      errorprone       : '1.3.0',
-      coveralls        : '2.8.1',
-      gradle           : '4.1.2',
-      dependencyUpdates: '0.36.0'
+          checkstyle       : '10.12.4',
+          errorprone       : '3.1.0',
+          gradle           : '8.1.4',
+          dependencyUpdates: '0.50.0'
   ]
 
   dependenciesList = [
-      // mapbox
-      mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
-      mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
-      mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
-      mapboxCore           : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
+          // mapbox - Using Maps SDK v11
+          mapboxMapSdk           : "com.mapbox.maps:android:${version.mapboxMapSdk}",
+          mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
+          mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
+          mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
 
-      // AutoValue
-      autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
-      autoValueAnnotations   : "com.google.auto.value:auto-value-annotations:${version.autoValue}",
+          // AutoValue
+          autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
+          autoValueAnnotations   : "com.google.auto.value:auto-value-annotations:${version.autoValue}",
 
-      // support
-      appcompat              : "androidx.appcompat:appcompat:1.2.0",
+          // support
+          appcompat              : "androidx.appcompat:appcompat:1.6.1",
 
-      // square crew
-      timber                 : "com.jakewharton.timber:timber:${version.timber}",
+          // square crew
+          timber                 : "com.jakewharton.timber:timber:${version.timber}",
 
-      // unit test
-      junit                  : "junit:junit:${version.junit}",
-      mockito                : "org.mockito:mockito-core:${version.mockito}",
-      hamcrest               : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
-      commonsIO              : "commons-io:commons-io:${version.commonsIO}",
-      robolectric            : "org.robolectric:robolectric:${version.robolectric}",
+          // unit test
+          junit                  : "junit:junit:${version.junit}",
+          mockito                : "org.mockito:mockito-core:${version.mockito}",
+          hamcrest               : "org.hamcrest:hamcrest:${version.hamcrest}",
+          commonsIO              : "commons-io:commons-io:${version.commonsIO}",
+          robolectric            : "org.robolectric:robolectric:${version.robolectric}",
 
-      errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}",
-      errorproneJavac        : "com.google.errorprone:javac:9+181-r4173-1"
+          errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}",
+          errorproneJavac        : "com.google.errorprone:javac:9+181-r4173-1"
   ]
 
   pluginDependencies = [
-      gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-      checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-      coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
-      errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
-      dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}"
+          gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+          checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+          errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
+          dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}"
   ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,8 +7,9 @@ ext {
   ]
 
   version = [
-          mapboxMapSdk       : '11.7.1',
-          mapboxCommon       : '24.7.1',
+          mapboxMapSdk       : '10.19.0',
+          mapboxSdkServices  : '5.8.0',
+          mapboxCore         : '3.1.0',
           autoValue          : '1.10.4',
           junit              : '4.13.2',
           mockito            : '5.6.0',
@@ -27,9 +28,11 @@ ext {
   ]
 
   dependenciesList = [
-          // mapbox - Using Maps SDK v11
-          mapboxMapSdk           : "com.mapbox.maps:android:${version.mapboxMapSdk}",
-          mapboxCommon           : "com.mapbox.common:common:${version.mapboxCommon}",
+          // mapbox - Using Maps SDK v10.19.0 with 16KB page size support
+          mapboxMapSdk           : "com.mapbox.maps:android-ndk27:${version.mapboxMapSdk}",
+          mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
+          mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
+          mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
 
           // AutoValue
           autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   version = [
           mapboxMapSdk       : '11.7.1',
           mapboxSdkServices  : '5.8.0',
-          mapboxCore         : '3.1.0',
+          mapboxCore         : '4.0.0',
           autoValue          : '1.10.4',
           junit              : '4.13.2',
           mockito            : '5.6.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip

--- a/navigation-android/build.gradle
+++ b/navigation-android/build.gradle
@@ -1,7 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
+  namespace 'com.mapbox.services.android.navigation'
   compileSdkVersion androidVersions.compileSdkVersion
+
+  buildFeatures {
+    buildConfig true
+  }
 
   defaultConfig {
     minSdkVersion androidVersions.minSdkVersion
@@ -9,14 +14,14 @@ android {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     buildConfigField('String',
-        "MAPBOX_NAVIGATION_SDK_IDENTIFIER", String.format("\"%s\"", "graphhopper-navigation-android")
+            "MAPBOX_NAVIGATION_SDK_IDENTIFIER", String.format("\"%s\"", "graphhopper-navigation-android")
     )
     buildConfigField('String',
-        "MAPBOX_NAVIGATION_VERSION_NAME", String.format("\"%s\"", project.VERSION_NAME)
+            "MAPBOX_NAVIGATION_VERSION_NAME", String.format("\"%s\"", project.VERSION_NAME)
     )
     buildConfigField "String",
-        "MAPBOX_NAVIGATION_EVENTS_USER_AGENT", String.format("\"graphhopper-navigation-android/%s\"",
-        project.VERSION_NAME
+            "MAPBOX_NAVIGATION_EVENTS_USER_AGENT", String.format("\"graphhopper-navigation-android/%s\"",
+            project.VERSION_NAME
     )
     consumerProguardFiles 'proguard-consumer.pro'
   }
@@ -32,8 +37,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   testOptions {

--- a/navigation-android/src/main/AndroidManifest.xml
+++ b/navigation-android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.mapbox.services.android.navigation">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <service android:name="com.mapbox.services.android.navigation.v5.navigation.NavigationService"/>

--- a/navigation-android/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationFasterRouteListenerTest.java
+++ b/navigation-android/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationFasterRouteListenerTest.java
@@ -15,7 +15,7 @@ import androidx.annotation.NonNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class NavigationFasterRouteListenerTest {
@@ -43,7 +43,7 @@ public class NavigationFasterRouteListenerTest {
 
     listener.onResponseReceived(response, routeProgress);
 
-    verifyZeroInteractions(eventDispatcher);
+    verifyNoInteractions(eventDispatcher);
   }
 
   @NonNull

--- a/navigation-android/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorThreadListenerTest.java
+++ b/navigation-android/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorThreadListenerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class RouteProcessorThreadListenerTest {
 
@@ -94,7 +94,7 @@ public class RouteProcessorThreadListenerTest {
 
     listener.onUserOffRoute(mock(Location.class), false);
 
-    verifyZeroInteractions(dispatcher);
+    verifyNoInteractions(dispatcher);
   }
 
   @Test
@@ -116,7 +116,7 @@ public class RouteProcessorThreadListenerTest {
 
     listener.onCheckFasterRoute(mock(Location.class), mock(RouteProgress.class), false);
 
-    verifyZeroInteractions(dispatcher);
+    verifyNoInteractions(dispatcher);
   }
 
   private RouteProcessorThreadListener buildListener(NavigationNotificationProvider provider) {


### PR DESCRIPTION
# Mapbox SDK Upgrade to 11.7.1

- Upgraded Mapbox SDK from version 9.2.1 to 11.7.1
- Updated Android target SDK to 34
- Fixed build issues and compatibility problems
- Updated all dependencies to latest versions
- Fixed test files for new Mockito version

## Key Changes
- **Mapbox SDK**: 9.2.1 → 11.7.1
- **Android SDK**: 29 → 34
- **Gradle**: Updated to 8.4
- **Dependencies**: Updated Mockito, Timber, and other libraries
- **Build System**: Fixed deprecated configurations
- **Tests**: Fixed compatibility issues
